### PR TITLE
chore: add vtu repo to ecosystem

### DIFF
--- a/tests/vtu.ts
+++ b/tests/vtu.ts
@@ -1,0 +1,14 @@
+import { runInRepo } from '../utils'
+import { RunOptions } from '../types'
+
+export async function test(options: RunOptions) {
+	await runInRepo({
+		...options,
+		repo: '@vuejs/test-utils',
+		overrides: {
+			'vue-tsc': true,
+		},
+		branch: 'main',
+		test: 'vue-tsc',
+	})
+}


### PR DESCRIPTION
Hi @johnsoncodehk 

I don't know if this is the proper way to add a repo, but it would be great to have VTU in the ecosystem ci, as we have a bunch of use cases with mounting components in tests that can be interesting to catch regressions